### PR TITLE
Fix NUMA exercise flow and Poker Train integration

### DIFF
--- a/numaEssentialOps.js
+++ b/numaEssentialOps.js
@@ -1,1095 +1,685 @@
-// 📁 mathMode/modules/numaEssentialOps.js
-// Módulo "NUMA" para Math Mode: Tablas básicas interacción tipo terminal
-// Se asume que `container` es el DIV `#math-exercise-area` dentro de mathModeOrquest.js
-
 import { renderExercises } from './NumaRender.js';
+import { createSpinner } from './numaSpinners.js';
 
-let leftCol = null;
-let pokerLevel = null; // ← AQUÍ
+const speedLabels = ['1H', '2H', '3H', '4H', '5H', '6H'];
 
+let termContainer = null;
+let configWrapper = null;
+let leftColumn = null;
+let numberGrid = null;
+let statsBox = null;
+let runButton = null;
+let pokerButton = null;
+let cfgContainer = null;
+let bottomRowRef = null;
+let buttonRowRef = null;
+let spinners = { start: null, end: null, chain: null };
+let fuguesSpeed = localStorage.getItem('fuguesSpeed') || '1H';
+let pokerDataPromise = null;
+let pokerSelection = { outs: [], types: [] };
+let pokerActive = false;
+let modeButtons = new Map();
 let speedButtons = [];
 
-const speedMap = {
-  '1H': 200,
-  '2H': 500,
-  '3H': 1000,
-  '4H': 2000,
-  '5H': 5000,
-  '6H': 10000
-};
-
-let currentSpeed = '1H';
-
-// ─────────────────────────────────────────────────────────
-// Teclado numérico on-screen (solo en móvil)
-
-
-
-export function init(container) {
- 
-  speedButtons.length = 0;
-  // ─── Ejercicios personalizados para modo Poker Train ───
-
-  // Limpiar contenido previo
-  container.innerHTML = '';
-
-  // Crear pantalla de terminal (solo este módulo)
-  const term = document.createElement('div');
-term.id = 'numa-terminal';
-term.className = 'numa-terminal';
-container.appendChild(term);
-
-
-
-
-
-  // ─────────────────────────────────────────────────────────
-  // Contenedor principal de configuración con dos columnas
-  // ─────────────────────────────────────────────────────────
-  const cfgContainer = document.createElement('div');
-  cfgContainer.className = 'numa-cfg-container';
-  term.appendChild(cfgContainer);
-
-  // ─────────────────────────────────────────────────────────
-  // COLUMNA IZQUIERDA: suma/resta arriba, mult/div abajo
-  // ─────────────────────────────────────────────────────────
-  leftCol = document.createElement('div');
-  leftCol.className = 'numa-cfg-col';
-  cfgContainer.appendChild(leftCol);
-
-  // Fila superior (suma y resta)
-  const leftTopRow = document.createElement('div');
-  leftTopRow.className = 'numa-cfg-row';
-  leftCol.appendChild(leftTopRow);
-  ['+','-'].forEach(label => {
-    const btn = document.createElement('button');
-    btn.textContent = label;
-    
-    btn.className = 'numa-btn';
-    btn.onclick = () => btn.classList.toggle('active');
-    leftTopRow.appendChild(btn);
-  });
-
-  // Fila inferior (multiplicación y división)
-  const leftBottomRow = document.createElement('div');
-  leftBottomRow.className = 'numa-cfg-row';
-  leftCol.appendChild(leftBottomRow);
-  ['×','÷'].forEach(label => {
-    const btn = document.createElement('button');
-    btn.textContent = label;
-    btn.className = 'numa-btn';
-    btn.onclick = () => btn.classList.toggle('active');
-    leftBottomRow.appendChild(btn);
-  });
-
-  // ─────────────────────────────────────────────────────────
-  // COLUMNA DERECHA: Random/Mirror/Cipher/Fugues arriba, Vanish/Surges/Pulsar/Shades abajo
-  // ─────────────────────────────────────────────────────────
-  const rightCol = document.createElement('div');
-  rightCol.className = 'numa-cfg-col';
-  cfgContainer.appendChild(rightCol);
-
-  // Fila superior de la derecha
-  const rightTopRow = document.createElement('div');
-rightTopRow.className = 'numa-cfg-row';
-rightCol.appendChild(rightTopRow);
-
-const modeLabels = {
-  Random: 'RND',
-  Mirror: 'MRR',
-  Surges: 'SRG',
-  Fugues: 'FGS'
-};
-
-['Random', 'Mirror', 'Surges', 'Fugues'].forEach(label => {
-  const btn = document.createElement('button');
-  btn.textContent = modeLabels[label] || label;
-  btn.className = 'numa-btn';
-  btn.dataset.mode = label; // ← esto es lo importante
-
-  if (label === 'Random')  btn.id = 'random-btn';
-  if (label === 'Mirror')  btn.id = 'mirror-btn';   // ← añade esto
-  if (label === 'Surges')  btn.id = 'surges-btn';
-  if (label === 'Fugues')  btn.id = 'fugues-btn';   // ← y esto
-
-  rightTopRow.appendChild(btn);
-});
-
-let randomBtn;
-let surgesBtn;
-const modeButtons = Array.from(rightTopRow.querySelectorAll('button.numa-btn'));
-
-randomBtn = modeButtons.find(b => b.dataset.mode === 'Random');
-surgesBtn = modeButtons.find(b => b.dataset.mode === 'Surges');
-
-
-
-
-
-// Si ya están duplicados por error, me cargo los clones sobrantes
-
-
-
-
-
-function forceActivateRandom() {
-
-  if (!randomBtn || !surgesBtn) {
-  console.warn('❌ No se puede forzar Random: botones no definidos');
-  return;
-}
-
-  if (!randomBtn.classList.contains('active')) {
-    randomBtn.classList.add('active');
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
   }
-  randomBtn.disabled = true;
-  randomBtn.classList.add('disabled');
-
-  surgesBtn.classList.remove('active');
-  surgesBtn.disabled = true;
-  surgesBtn.classList.add('disabled');
-
-  updateRunButtonState();
+  return array;
 }
 
-modeButtons.forEach(btn => {
-  const mode = btn.dataset.mode;
+function mirrorExpression(expr) {
+  const tokens = expr.split(/([+\-×÷])/).map(t => t.trim()).filter(Boolean);
+  const values = [];
+  const ops = [];
+  tokens.forEach((token, idx) => {
+    if (idx % 2 === 0) values.push(token);
+    else ops.push(token);
+  });
+  values.reverse();
+  ops.reverse();
+  let result = values[0];
+  for (let i = 0; i < ops.length; i++) {
+    const val = values[i + 1];
+    if (val === undefined) break;
+    result += ` ${ops[i]} ${val}`;
+  }
+  return result;
+}
 
-  // Saltamos los que ya tienen su listener independiente
-  if (mode === 'Random' || mode === 'Surges') return;
+function evaluateExpression(expr) {
+  const jsExpr = expr.replace(/×/g, '*').replace(/÷/g, '/');
+  try {
+    const value = Function(`"use strict";return (${jsExpr});`)();
+    return Number.isFinite(value) ? value : null;
+  } catch (err) {
+    console.error('Error evaluando expresión', expr, err);
+    return null;
+  }
+}
 
-  btn.addEventListener('click', () => {
-    if (btn.disabled) return;
+function formatNumeric(value) {
+  if (value === null || value === undefined) return '';
+  const rounded = Math.round(value * 100) / 100;
+  if (Number.isInteger(rounded)) return String(rounded);
+  return rounded.toFixed(2).replace(/\.0+$/,'').replace(/0+$/,'');
+}
 
-    const isActive = btn.classList.toggle('active');
+function calc(current, op, operand) {
+  switch (op) {
+    case '+': return current + operand;
+    case '-': return current - operand;
+    case '×': return current * operand;
+    case '÷': return operand === 0 ? null : current / operand;
+    default: return null;
+  }
+}
 
-    if (mode === 'Fugues') {
-      // 1) Habilita/deshabilita los speedButtons
-      speedButtons.forEach(b => {
-        b.disabled = !isActive;
-        b.classList.toggle('disabled', !isActive);
-        b.classList.remove('active'); // quitamos cualquier selección previa
-      });
+function getActiveOperations() {
+  if (!leftColumn) return [];
+  return Array.from(leftColumn.querySelectorAll('button.numa-btn.active')).map(btn => btn.dataset.op);
+}
 
-      // 2) Si activamos Fugues, marcamos la velocidad por defecto
-      if (isActive) {
-        const defaultSpeed = speedButtons[0];
-        defaultSpeed.classList.add('active');
-        currentSpeed = defaultSpeed.dataset.spinSpeed;
+function getSelectedNumbers() {
+  if (!numberGrid) return [];
+  return Array.from(numberGrid.querySelectorAll('button.numa-num-btn.active')).map(btn => Number(btn.textContent));
+}
+
+function getModes() {
+  return Array.from(modeButtons.entries())
+    .filter(([, btn]) => btn.classList.contains('active'))
+    .map(([mode]) => mode);
+}
+
+function clampChain(value) {
+  if (Number.isNaN(value) || value < 2) return 2;
+  return Math.min(value, 4);
+}
+
+function readSpinners() {
+  const start = Math.max(1, Number(spinners.start.value) || 1);
+  const end = Math.max(start, Number(spinners.end.value) || start);
+  const chain = clampChain(Number(spinners.chain.value) || 2);
+  spinners.start.value = String(start);
+  spinners.end.value = String(end);
+  spinners.chain.value = String(chain);
+  return { start, end, chain };
+}
+
+function enforceChainRules() {
+  const { chain } = readSpinners();
+  const randomBtn = modeButtons.get('Random');
+  const surgesBtn = modeButtons.get('Surges');
+
+  if (chain >= 3) {
+    if (surgesBtn) {
+      surgesBtn.classList.remove('active');
+      surgesBtn.disabled = true;
+      surgesBtn.classList.add('disabled');
+    }
+    if (randomBtn) {
+      randomBtn.classList.add('active');
+      randomBtn.disabled = true;
+      randomBtn.classList.add('disabled');
+    }
+  } else {
+    if (surgesBtn) {
+      surgesBtn.disabled = false;
+      surgesBtn.classList.remove('disabled');
+    }
+    if (randomBtn) {
+      randomBtn.disabled = false;
+      randomBtn.classList.remove('disabled');
+    }
+  }
+}
+
+function updateFuguesSpeedButtons(active) {
+  speedButtons.forEach(btn => {
+    btn.disabled = !active;
+    btn.classList.toggle('disabled', !active);
+    btn.classList.toggle('active', btn.dataset.speed === fuguesSpeed && active);
+  });
+}
+
+function updateRunButtonState() {
+  const ops = getActiveOperations();
+  const nums = getSelectedNumbers();
+  const pokerReady = pokerActive && pokerSelection.outs.length > 0 && pokerSelection.types.length > 0;
+  const ready = (ops.length > 0 && nums.length > 0) || pokerReady;
+  if (runButton) {
+    runButton.disabled = !ready;
+    runButton.classList.toggle('disabled', !ready);
+  }
+  updateStats();
+}
+
+function updateStats() {
+  if (!statsBox) return;
+  const ops = getActiveOperations().length;
+  const nums = getSelectedNumbers().length;
+  const { start, end, chain } = readSpinners();
+  const rangeSize = end - start + 1;
+  const numericCount = ops === 0 || nums === 0 ? 0 : ops * nums * Math.pow(rangeSize, Math.max(chain - 1, 1));
+  const pokerCount = pokerActive ? pokerSelection.outs.length * pokerSelection.types.length : 0;
+  statsBox.textContent = `NUMA: ${numericCount}  Poker: ${pokerCount}  Total: ${numericCount + pokerCount}`;
+}
+
+function generateNumericExercises(modes) {
+  const ops = getActiveOperations();
+  const numbers = getSelectedNumbers();
+  if (ops.length === 0 || numbers.length === 0) return [];
+  const { start, end, chain } = readSpinners();
+  const rangeValues = [];
+  for (let value = start; value <= end; value++) {
+    rangeValues.push(value);
+  }
+
+  const expressions = [];
+  const build = (depth, currentValue, exprParts) => {
+    if (depth === chain - 1) {
+      expressions.push(exprParts.join(' '));
+      return;
+    }
+    for (const op of ops) {
+      for (const val of rangeValues) {
+        const result = calc(currentValue, op, val);
+        if (result === null || !Number.isFinite(result)) continue;
+        build(depth + 1, result, [...exprParts, op, val]);
       }
     }
-
-    updateRunButtonState();
-  });
-});
-
-
-
-
-
-
-const speedRow = document.createElement('div');
-speedRow.className = 'numa-cfg-row speed-row';
-rightCol.appendChild(speedRow);
-// Crear botones de velocidad y añadirlos a speedRow
-const speedLabels = ['1H','2H','3H','4H','5H','6H'];
-
-speedLabels.forEach(label => {
-  const btn = document.createElement('button');
-  btn.textContent = label;
-  btn.dataset.spinSpeed = label;
-  btn.className = 'numa-btn';
-  btn.disabled = true;
-
-  btn.onclick = () => {
-    if (btn.disabled) return;
-    // Desactiva todos los demás
-    speedButtons.forEach(sb => sb.classList.remove('active'));
-    btn.classList.add('active');
-
-    // Guarda velocidad actual
-    currentSpeed = label;
-    localStorage.setItem('fuguesSpeed', currentSpeed);
   };
 
-  speedButtons.push(btn);
-  speedRow.appendChild(btn);
-});
-
-// ¡Ahora definimos speedButtons justo tras crear todos los botones!
-
-
-
-
-
-
-
-
-
-
-  // ─────────────────────────────────────────────────────────
-  // Selector de tablas (botones 1-100 en grid 10×10)
-  // ─────────────────────────────────────────────────────────
-  const scroll = document.createElement('div');
-  scroll.className = 'numa-scroll';
-  for (let i = 1; i <= 100; i++) {
-    const btnNum = document.createElement('button');
-    btnNum.textContent = i;
-    btnNum.className = 'numa-num-btn';
-    btnNum.onclick = () => btnNum.classList.toggle('active');
-    scroll.appendChild(btnNum);
-  }
-  term.appendChild(scroll);
- 
-
-
-  // ─────────────────────────────────────────────────────────
-  // Fila inferior: Inicio, Fin, Chain debajo de la tabla
-  // ─────────────────────────────────────────────────────────
-  const rowBottom = document.createElement('div');
-  rowBottom.className = 'numa-bottom';
-  term.appendChild(rowBottom);
-
-  // Función auxiliar para crear un spinner personalizado
-  function createSpinner(labelText, inputId, initialValue, refs = {}) {
- 
-    const existing = document.getElementById(inputId);
-  if (existing) existing.remove();
-  
-    const wrapper = document.createElement('div');
-    wrapper.classList.add('numa-input-group');
-    wrapper.style.display = 'flex';
-    wrapper.style.alignItems = 'center';
-    wrapper.style.gap = '0.3em';
-
-    const lbl = document.createElement('label');
-    lbl.textContent = labelText;
-    lbl.style.color = '#28a746';
-    lbl.style.fontSize = '0.8rem';
-    lbl.style.display = 'flex';
-    lbl.style.alignItems = 'center';
-    lbl.style.gap = '0.2em';
-
-    const spinner = document.createElement('div');
-    spinner.className = 'numa-spinner';
-
-    const input = document.createElement('input');
-    input.type = 'number';
-    input.id = inputId;
-    input.value = String(initialValue);
-    // Ajustar el mínimo para "chain" en 2; para inicio/fin, mínimo 1
-    input.min = (inputId === 'numa-chain') ? '2' : '1';
-
-    const btnContainer = document.createElement('div');
-    btnContainer.style.display = 'flex';
-    btnContainer.style.flexDirection = 'column';
-
-    const btnUp = document.createElement('button');
-    btnUp.className = 'numa-spinner-btn up';
-    btnUp.innerHTML = '<span class="icon-up">▲</span>';
-   btnUp.onclick = () => {
-  let val = parseInt(input.value || '0', 10);
-  val = isNaN(val) ? (inputId === 'numa-chain' ? 2 : 1) : val + 1;
-
-  // Validaciones de límite
-  if (inputId === 'numa-chain' && val < 2) {
-    val = 2;
-  }
-  if (inputId === 'numa-start') {
-    let e = parseInt(document.getElementById('numa-end').value, 10);
-    if (isNaN(e) || e < 1) e = 1;
-    if (val > e) val = e;
-  }
-  if (inputId === 'numa-end') {
-    let s = parseInt(document.getElementById('numa-start').value, 10);
-    if (isNaN(s) || s < 1) s = 1;
-    if (val < s) val = s;
+  for (const base of numbers) {
+    build(0, base, [base]);
   }
 
-  input.value = String(val);
-  input.dispatchEvent(new Event('input'));
-};
-
-    const btnDown = document.createElement('button');
-    btnDown.className = 'numa-spinner-btn down';
-    btnDown.innerHTML = '<span class="icon-down">▼</span>';
-    btnDown.onclick = () => {
-  let val = parseInt(input.value || '0', 10);
-  val = isNaN(val) ? (inputId === 'numa-chain' ? 2 : 1) : val - 1;
-
-  // 1) Mínimos absolutos
-  if (inputId === 'numa-chain' && val < 2) {
-    val = 2;
+  let finalExpressions = expressions;
+  if (modes.includes('Mirror')) {
+    finalExpressions = finalExpressions.map(mirrorExpression);
   }
-  if ((inputId === 'numa-start' || inputId === 'numa-end') && val < 1) {
-    val = 1;
-  }
-
-  // 2) Validaciones cruzadas start/end
-  if (inputId === 'numa-start') {
-    let e = parseInt(document.getElementById('numa-end').value, 10);
-    if (isNaN(e) || e < 1) e = 1;
-    if (val > e) val = e;
-  }
-  if (inputId === 'numa-end') {
-    let s = parseInt(document.getElementById('numa-start').value, 10);
-    if (isNaN(s) || s < 1) s = 1;
-    if (val < s) val = s;
-  }
-
-  input.value = String(val);
-  input.dispatchEvent(new Event('input'));
-};
-
-    btnContainer.appendChild(btnUp);
-    btnContainer.appendChild(btnDown);
-    spinner.appendChild(input);
-    spinner.appendChild(btnContainer);
-    lbl.appendChild(spinner);
-    wrapper.appendChild(lbl);
-
-    return wrapper;
-  }
-
-  // “Inicio” spinner
-  const inicioSpinner = createSpinner('Inicio:', 'numa-start', 1);
-  rowBottom.appendChild(inicioSpinner);
-
-  // “Fin” spinner
-  const finSpinner = createSpinner('Fin:', 'numa-end', 10);
-  rowBottom.appendChild(finSpinner);
-
-  // “Chain” spinner
-  const chainSpinner = createSpinner('Chain:', 'numa-chain', 2);
-  rowBottom.appendChild(chainSpinner);
-  const chainInputEl = chainSpinner.querySelector('input[type="number"]');
-if (chainInputEl) {
-  chainInputEl.addEventListener('input', validateSpinners);
-}
-
-  // ─────────────────────────────────────────────────────────
-  // Referencias a inputs para restricciones adicionales
-  // ─────────────────────────────────────────────────────────
-  const inicioInput = document.getElementById('numa-start');
-  const finInput    = document.getElementById('numa-end');
-  const chainInput  = document.getElementById('numa-chain');
-
-if (randomBtn && surgesBtn && chainInput) {
-  randomBtn.addEventListener('click', () => {
-    if (!chainInput) {
-      console.warn('⚠️ randomBtn handler cancelado: chainInput no disponible');
-      return;
-    }
-
-    const chain = parseInt(chainInput.value, 10);
-    if (chain >= 3) {
-      console.log('⛔ Chain >= 3: Random forzado, Surges desactivado');
-      forceActivateRandom();
-      return;
-    }
-
-    if (randomBtn.disabled) return;
-
-    const isNowActive = !randomBtn.classList.contains('active');
-    randomBtn.classList.toggle('active', isNowActive);
-    if (isNowActive) {
-      surgesBtn.classList.remove('active');
-    }
-
-    updateRunButtonState();
-  });
-
-  surgesBtn.addEventListener('click', () => {
-    if (!chainInput) {
-      console.warn('⚠️ surgesBtn handler cancelado: chainInput no disponible');
-      return;
-    }
-
-    const chain = parseInt(chainInput.value, 10);
-    if (chain >= 3) {
-      console.log('⛔ Chain >= 3: Surges bloqueado');
-      return;
-    }
-
-    if (surgesBtn.disabled) return;
-
-    const isNowActive = !surgesBtn.classList.contains('active');
-    surgesBtn.classList.toggle('active', isNowActive);
-    if (isNowActive) {
-      randomBtn.classList.remove('active');
-    }
-
-    updateRunButtonState();
-  });
-} else {
-  console.warn('⚠️ Botones Random/Surges o chainInput no definidos todavía');
-}
-
-
-function validateSpinners() {
-  console.log('🛠️ validateSpinners() ejecutada');
-
-  if (!randomBtn || !surgesBtn) {
-  console.warn('⚠️ validateSpinners cancelado: botones no definidos todavía');
-  return;
-}
-
-  // 1. Normaliza chain
-  let chain = parseInt(chainInput.value, 10);
-  if (isNaN(chain) || chain < 2) {
-    chain = 2;
-    chainInput.value = '2';
-  }
-
-  // 2. Obtener botones Random y Surges
- 
-
-  console.log(`🎛️ Antes – Random(active=${randomBtn.classList.contains('active')}), Surges(active=${surgesBtn.classList.contains('active')})`);
-
-  // 3. Lógica según chain
-  if (chain >= 3) {
-    // 🔒 Forzar Random activo
-    if (!randomBtn.classList.contains('active')) {
-      randomBtn.classList.add('active');
-    }
-
-    randomBtn.disabled = true;
-    randomBtn.classList.add('disabled');
-
-    // ❌ Desactivar Surges
-    surgesBtn.classList.remove('active');
-    surgesBtn.disabled = true;
-    
-  } else {
-    // 🔓 Dejar ambos activables pero mutuamente excluyentes
-    randomBtn.disabled = false;
-    randomBtn.classList.remove('disabled');
-
-    surgesBtn.disabled = false;
-    surgesBtn.classList.remove('disabled');
-
-    if (randomBtn.classList.contains('active')) {
-      surgesBtn.classList.remove('active');
-    }
-    if (surgesBtn.classList.contains('active')) {
-      randomBtn.classList.remove('active');
-    }
-  }
-
-  console.log(`🎛️ Después – Random(active=${randomBtn.classList.contains('active')}), Surges(active=${surgesBtn.classList.contains('active')})`);
-
-  updateRunButtonState();
-
-  // 4. Validación final de rangos
-  let start = parseInt(inicioInput.value, 10) || 1;
-  let end   = parseInt(finInput.value,   10) || 1;
-  if (start > end) {
-    start = end;
-    inicioInput.value = String(end);
-  }
-  if (end < start) {
-    end = start;
-    finInput.value = String(start);
-  }
-}
-
-
-
-
-
-  // ─────────────────────────────────────────────────────────
-  // Ajustes para evitar valores inválidos:
-  //   - Chain no puede bajar menos de 2
-  //   - Inicio no puede superar a Fin y viceversa
-  // ─────────────────────────────────────────────────────────
-
-
-
-  // ─────────────────────────────────────────────────────────
-  // Estadísticas en tiempo real
-  // ─────────────────────────────────────────────────────────
-  const stats = document.createElement('div');
-  stats.id = 'numa-stats';
-  stats.className = 'numa-stats';
-  term.appendChild(stats);
-
-  // ─────────────────────────────────────────────────────────
-  // Botón Comenzar
-  // ─────────────────────────────────────────────────────────
-  const run = document.createElement('button');
-  run.textContent = 'Comenzar';
-  run.classList.add('numa-btn', 'start-btn', 'disabled');
-  run.disabled = true;
-
-  const pokerBtn = document.createElement('button');
-  pokerBtn.textContent = 'Poker Train';
-  pokerBtn.classList.add('numa-btn');
-
-  const btnRow = document.createElement('div');
-  btnRow.className = 'numa-btn-row';
-  btnRow.appendChild(run);
-  btnRow.appendChild(pokerBtn);
-
-  container.appendChild(btnRow);
-  // ✅ AHORA SÍ: ya existen run y pokerBtn, así que ahora podemos usar validateSpinners
-[inicioInput, finInput, chainInput].forEach(inp =>
-  inp.addEventListener('input', validateSpinners)
-);
-
-
-
-// Añadir los botones FUERA de #numa-terminal para que sobrevivan al limpiar
-
-
-function resetAllSelections() {
-  // 1. Resetear operaciones activas
-  const opBtns = document.querySelectorAll('button.numa-btn');
-  opBtns.forEach(btn => {
-    btn.classList.remove('active');
-  });
-
-  // 2. Resetear botones de tablas (1–100)
-  const numBtns = document.querySelectorAll('button.numa-num-btn');
-  numBtns.forEach(btn => {
-    btn.classList.remove('active');
-    btn.disabled = false;
-    btn.classList.remove('disabled');
-
-    // ✅ Ya no clonas: solo limpias y reactivas
-    btn.onclick = () => {
-      btn.classList.toggle('active');
-      updateRunButtonState();
-    };
-  });
-
-  // 3. Resetear nivel de Poker
-  speedButtons.forEach(btn => {
-  btn.classList.remove('active');
-  btn.disabled = true;
-  btn.classList.add('disabled');
-});
-  pokerLevel = null;
-  attachListenersToTableButtons();
-}
-
-let isPokerTrainActive = false;
-
-pokerBtn.addEventListener('click', () => {
-  const wasActive = pokerBtn.classList.contains('active');
-
-  resetAllSelections(); // Esto borra todas las clases .active
-
- if (wasActive) {
-  pokerBtn.classList.remove('active');
-  isPokerTrainActive = false;
-  
-
-  // Desactivar botón Comenzar al salir de Poker Train
-  run.disabled = true;
-  run.classList.add('disabled');
-
-} else {
-  pokerBtn.classList.add('active');
-  isPokerTrainActive = true;
-
-  document.getElementById('numa-start').value = '1';
-  document.getElementById('numa-end').value = '10';
-  document.getElementById('numa-chain').value = '2';
-  validateSpinners();
-
-}
-updateTableButtonsForPokerTrain(isPokerTrainActive);
-  const active = isPokerTrainActive;
-  pokerLevel = null;
-
-
-  // A) Spinners
-  ['numa-start', 'numa-end', 'numa-chain'].forEach(id => {
-  const input = document.getElementById(id);
-  if (!input) return;
-
-  input.disabled = active;
-  input.classList.toggle('disabled', active);
-  if (active) input.blur();
-
-  const group = input.closest('.numa-input-group') || input.parentElement;
-  if (!group) return;
-
-  group.classList.toggle('disabled', active);
-
-  // Desactiva botones visibles
-  group.querySelectorAll('button').forEach(btn => {
-    btn.disabled = active;
-    btn.classList.toggle('disabled', active);
-  });
-
-  // Atenúa textos visibles
-  group.querySelectorAll('label, span, p').forEach(el => {
-    el.classList.toggle('disabled', active);
-  });
-});
-
-
-  // B) Tabla: solo 1–4 si está activo
-  updateTableButtonsForPokerTrain(active);
-
-  if (active) {
-    // C) Desactivar modos avanzados
-    ['Mirror', 'Surges'].forEach(lbl => {
-      const m = modeButtons.find(b => b.textContent === lbl);
-      m.disabled = true;
-      m.classList.add('disabled');
-      m.classList.remove('active');
-    });
-
-    updateRunButtonState(); // solo al entrar, no al salir
-
-   
-
-  } else {
-    // Rehabilitar botones
-    ['Mirror', 'Surges'].forEach(lbl => {
-      const m = modeButtons.find(b => b.textContent === lbl);
-      m.disabled = false;
-      m.classList.remove('disabled');
+  if (modes.includes('Surges')) {
+    finalExpressions = finalExpressions.slice().sort((a, b) => {
+      const av = Math.abs(evaluateExpression(a) ?? 0);
+      const bv = Math.abs(evaluateExpression(b) ?? 0);
+      return av - bv;
     });
   }
 
-  // ← 🔧 Asegúrate de que el botón Comenzar refleja el nuevo estado
-  updateRunButtonState();
-});
-
-function attachListenersToTableButtons() {
-  scroll.querySelectorAll('button.numa-num-btn')
-    .forEach(b => b.addEventListener('click', updateRunButtonState));
+  const templates = [];
+  for (const expr of finalExpressions) {
+    const result = evaluateExpression(expr);
+    if (result === null) continue;
+    templates.push({
+      kind: 'numeric',
+      prompt: `${expr} =`,
+      answer: formatNumeric(result),
+      numericAnswer: result
+    });
+  }
+  return templates;
 }
 
-// Actualiza estado del botón Comenzar
-function updateRunButtonState() {
-  if (!leftCol || !scroll) return;
-  if (typeof pokerBtn === 'undefined' || pokerBtn === null) {
-    console.warn('⚠️ updateRunButtonState(): pokerBtn no está definido aún');
-    return;
+async function loadPokerData() {
+  if (!pokerDataPromise) {
+    pokerDataPromise = fetch('./potOdds.json')
+      .then(resp => {
+        if (!resp.ok) throw new Error('No se pudo cargar potOdds.json');
+        return resp.json();
+      })
+      .catch(err => {
+        pokerDataPromise = null;
+        console.error(err);
+        throw err;
+      });
   }
-  const opSelected = Array.from(leftCol.querySelectorAll('button.numa-btn.active')).length > 0;
-  const numSelected = Array.from(scroll.querySelectorAll('button.numa-num-btn.active')).length > 0;
-  const pokerOn = pokerBtn?.classList.contains('active') ?? false;
-
-  // Caso especial: Poker Train activado → verificar si se seleccionó un nivel (1-4)
-    if (pokerOn) {
-    const validPoker = pokerLevel >= 1 && pokerLevel <= 4;
-    if (validPoker && opSelected) {
-      run.disabled = false;
-      run.classList.remove('disabled');
-    } else {
-      run.disabled = true;
-      run.classList.add('disabled');
-    }
-    return;
-  }
-
-
-  // Caso normal (no Poker Train)
-  if (opSelected && numSelected) {
-    run.disabled = false;
-    run.classList.remove('disabled');
-  } else {
-    run.disabled = true;
-    run.classList.add('disabled');
-  }
-}
-// Adjuntar listeners
-leftCol.querySelectorAll('button.numa-btn').forEach(b => b.addEventListener('click', updateRunButtonState));
-scroll.querySelectorAll('button.numa-num-btn').forEach(b => b.addEventListener('click', updateRunButtonState));
-
-// Estado inicial
-if (pokerBtn) {
-  updateRunButtonState();
-} else {
-  console.warn('⚠️ No se puede ejecutar updateRunButtonState(): pokerBtn no está definido');
+  return pokerDataPromise;
 }
 
+function buildPokerTemplate(out, typeKey, data, meta) {
+  const typeMap = {
+    percent_flop_turn: { label: 'Flop→Turn (%)', path: ['flop_turn', 'percent'], format: v => Number(v).toFixed(meta.precision.percent_dp) },
+    percent_turn_river: { label: 'Turn→River (%)', path: ['turn_river', 'percent'], format: v => Number(v).toFixed(meta.precision.percent_dp) },
+    percent_flop_river: { label: 'Flop→River (%)', path: ['flop_river', 'percent'], format: v => Number(v).toFixed(meta.precision.percent_dp) },
+    odds_flop_turn: { label: 'Flop→Turn (odds)', path: ['flop_turn', 'odds_display'], format: v => String(v) },
+    odds_turn_river: { label: 'Turn→River (odds)', path: ['turn_river', 'odds_display'], format: v => String(v) },
+    odds_flop_river: { label: 'Flop→River (odds)', path: ['flop_river', 'odds_display'], format: v => String(v) },
+    percent_to_odds: { label: 'Convierte % → odds', path: ['flop_turn', 'percent'], format: v => ((100 - Number(v)) / Number(v)).toFixed(meta.precision.odds_dp) },
+    odds_to_percent: { label: 'Convierte odds → %', path: ['flop_turn', 'odds_against'], format: v => (100 / (Number(v) + 1)).toFixed(meta.precision.percent_dp) }
+  };
 
-  // ─────────────────────────────────────────────────────────
-  // Área de resultados
-  // ─────────────────────────────────────────────────────────
-  const output = document.createElement('div');
-  output.id = 'numa-output';
-  output.className = 'numa-output';
-  term.appendChild(output);
-
-  // ─────────────────────────────────────────────────────────
-  // Función que reemplaza todo el contenido con ejercicio secuencial
-  // ─────────────────────────────────────────────────────────
-  
- 
-
-  // 📦 Datos Poker Train: bloques de dificultad  
-const pokerOps = {
-  1: { // BLOQUE 1 — FUNDAMENTALES :contentReference[oaicite:0]{index=0}
-    '×': ['2×2=4','2×3=6','2×4=8','2×5=10','3×2=6','3×3=9','4×3=12','5×2=10','5×3=15','5×4=20','6×2=12','6×3=18','10×10=100'],
-    '+': ['1.5+1.5=3','2+2.5=4.5','2.5+2.5=5','3+3=6','5+5=10','6+6=12','10+15=25','25+25=50'],
-    '-': ['10-2.5=7.5','15-5=10','25-15=10','50-25=25'],
-    '÷': ['2÷2=1','4÷2=2','6÷2=3','10÷2=5','10÷5=2','20÷4=5','60÷10=6','100÷10=10']
-  },
-  2: { // BLOQUE 2 — INTERMEDIO :contentReference[oaicite:1]{index=1}
-    '×': ['2×1.5=3','2×2.5=5','3×1.5=4.5','3×2.5=7.5','4×2.5=10','4×3.5=14','5×2=10','6×1.5=9','7.5×2=15','10×1.5=15','1.25×4=5','1.25×8=10','1.5×10=15'],
-    '+': ['1+1.5=2.5','2.5+1.5=4','2.5+3=5.5','3.5+1.5=5','4.5+1.5=6','4.5+4.5=9','7.5+7.5=15'],
-    '-': ['7.5-2.5=5','10-1.5=8.5','20-7.5=12.5','25-7.5=17.5','30-7.5=22.5','50-15=35'],
-    '÷': ['1÷2=0.5','1÷4=0.25','1÷5=0.2','2÷1.5=1.33','3÷1.25=2.4','3÷4=0.75','4÷4=1','5÷1.5=3.33','5÷5=1','6÷3=2']
-  },
-  3: { // BLOQUE 3 — AVANZADO :contentReference[oaicite:2]{index=2}
-    '×': ['2.5×2=5','2.5×3=7.5','2.5×4=10','2.5×6=15','2.5×10=25','3.5×2=7','3.5×3=10.5','3.5×4=14','4.5×2=9','4.5×3=13.5','4.5×4=18'],
-    '+': ['3+4.5=7.5','12.5+25=37.5','25+50=75','75+75=150'],
-    '-': ['10-1.25=8.75','10-1.75=8.25','25-12.5=12.5','30-12.5=17.5','100-75=25'],
-    '÷': ['1÷3=0.33','1÷1.25=0.8','1÷1.75=0.57','1÷2.25=0.44','2÷1.75=1.14','2.5÷1.25=2','3.5÷1.25=2.8','4.5÷1.5=3','7.5÷2.5=3','10÷3=3.33','15÷2.5=6','27÷18.5=1.46']
-  },
-  4: { // BLOQUE 4 — PÓKER PRO :contentReference[oaicite:3]{index=3}
-    '×': ['1.25×6=7.5','1.25×12=15','1.5×12=18','1.5×15=22.5','1.5×20=30','1.75×4=7','1.75×6=10.5','1.75×8=14','1.75×10=17.5','2.25×4=9','2.25×6=13.5','2.25×10=22.5','2.75×6=16.5','2.75×10=27.5'],
-    '+': ['7.5+10=17.5','15+15=30'],
-    '-': ['100-37.5=62.5'],
-    '÷': ['3÷7=0.43','4÷1.75=2.29','5÷6=0.83','6÷2.5=2.4','9÷4.5=2','10÷2.5=4','15÷1.5=10','20÷5=4','25÷5.5=4.54','30÷6=5','30÷7.5=4','35÷8.5=4.11','40÷9.5=4.21','45÷12.5=3.6','70÷10=7','75÷7.5=10','80÷10=8','100÷8=12.5']
+  const cfg = typeMap[typeKey];
+  if (!cfg) return null;
+  const base = data[out];
+  if (!base) return null;
+  let value = base;
+  for (const key of cfg.path) {
+    value = value?.[key];
+    if (value === undefined) return null;
   }
-};
+  const formatted = cfg.format ? cfg.format(value) : String(value);
+  const prompt = `Outs ${out} · ${cfg.label}`;
+  return {
+    kind: 'text',
+    prompt: `${prompt} =`,
+    answer: String(formatted).replace(/\.0+$/,'').replace(/0+$/,'')
+  };
+}
 
-// Actualiza estado del botón Comenzar
-
-
-function getActiveOps() {
-  if (!leftCol) {
-    console.warn('⚠️ getActiveOps(): leftCol no está disponible');
+async function generatePokerExercises() {
+  if (!pokerActive) return [];
+  let data;
+  try {
+    data = await loadPokerData();
+  } catch (error) {
+    alert('No se pudieron cargar los datos de Poker Train.');
+    setPokerActive(false);
     return [];
   }
-  return Array.from(leftCol.querySelectorAll('button.numa-btn.active'))
-    .map(b => b.textContent);
+  const meta = data.potOdds.meta;
+  const outsData = data.potOdds.outs;
+  const exercises = [];
+  for (const out of pokerSelection.outs) {
+    for (const typeKey of pokerSelection.types) {
+      const tpl = buildPokerTemplate(String(out), typeKey, outsData, meta);
+      if (tpl) {
+        exercises.push(tpl);
+      }
+    }
+  }
+  return exercises;
 }
-  // ─────────────────────────────────────────────────────────
-  // Manejo del clic en “Comenzar”
-  // ─────────────────────────────────────────────────────────
- run.onclick = () => {
-  document.querySelectorAll('#controls, #quiz-section, #memory-controls').forEach(el => {
-    el.style.display = 'none';
+
+function setPokerActive(active) {
+  pokerActive = active;
+  pokerButton.classList.toggle('active', active);
+  ['start', 'end', 'chain'].forEach(key => {
+    const input = spinners[key];
+    input.disabled = active;
+    input.classList.toggle('disabled', active);
+    const wrapper = input.closest('.numa-input-group');
+    if (wrapper) wrapper.classList.toggle('disabled', active);
   });
-
-  Array.from(document.body.children).forEach(child => {
-    if (
-      !child.contains(container) &&
-      !child.matches('#math-panel')
-    ) {
-      child.style.visibility = 'hidden';
-    }
-  });
-
-  btnRow.remove();
-  console.log('Click en Comenzar');
-
-  if (pokerLevel !== null) {
-    const opsLeft = getActiveOps(); // botones + − × ÷
-    const selectedOps = pokerOps[pokerLevel];
-    const expressions = [];
-
-    opsLeft.forEach(op => {
-      if (selectedOps[op]) {
-        const cleaned = selectedOps[op].map(expr => expr.split('=')[0].trim());
-        expressions.push(...cleaned);
-      }
-    });
-
-    const numaSubbar = document.getElementById('numa-subbar');
-    if (numaSubbar) numaSubbar.style.visibility = 'hidden';
-
-    const topbar = document.getElementById('math-topbar');
-    if (topbar) topbar.style.visibility = 'hidden';
-
-    const cfgContainerEl = document.querySelector('.numa-cfg-container');
-    if (cfgContainerEl) cfgContainerEl.style.visibility = 'hidden';
-
-    document.body.style.backgroundColor = 'black';
-
-    renderExercises(expressions, opsLeft);
-
-    setTimeout(() => {
-  const darkBtn = document.querySelector('.dark-override-btn');
-  if (darkBtn) darkBtn.click();
-  else console.warn('❌ No se encontró el botón del ojito a tiempo');
-}, 50);
-
-    return; // salta el resto del comportamiento clásico
-  
-};
-    // 1) Ocultar elementos de configuración
-    const numaSubbar = document.getElementById('numa-subbar');
-    if (numaSubbar) numaSubbar.style.visibility = 'hidden';
-
-    const topbar = document.getElementById('math-topbar');
-    if (topbar) topbar.style.visibility = 'hidden';
-
-    const cfgContainerEl = document.querySelector('.numa-cfg-container');
-    if (cfgContainerEl) cfgContainerEl.style.visibility = 'hidden';
-
-    // 2) Ocultar TODO lo demás en la página (excepto #math-panel)
-    document.body.style.backgroundColor = 'black';
-    Array.from(document.body.children).forEach(child => {
-      if (!child.contains(container)) {
-        child.style.visibility = 'hidden';
-      }
-    });
-
-    // 3) Recoger operaciones “activas” en la columna izquierda
-    const opsLeft = Array.from(leftCol.querySelectorAll('button.numa-btn'))
-      .filter(b => b.classList.contains('active'))
-      .map(b => b.textContent);
-
-    // 4) Recoger botones “extra” en la columna derecha (Random, etc.)
-  const opsRight = [];
-  if (randomBtn?.classList.contains('active')) opsRight.push('Random');
-  if (surgesBtn?.classList.contains('active')) opsRight.push('Surges');
-  const mirrorBtn = document.getElementById('mirror-btn');
-  if (mirrorBtn?.classList.contains('active')) opsRight.push('Mirror');
-  const fuguesBtn = document.getElementById('fugues-btn');
-  if (fuguesBtn?.classList.contains('active')) opsRight.push('Fugues');
-
-
-
-    // 5) Recoger los números de “tabla” seleccionados (por ejemplo, 1 y 2)
-    let nums = Array.from(scroll.querySelectorAll('button.numa-num-btn.active'))
-      .map(b => +b.textContent);
-
-      if (nums.length === 0) nums = [1];
-    // 6) Leer los valores de “Inicio” y “Fin” (spinners). Asegurar que inicio ≤ fin
-    let s = parseInt(document.getElementById('numa-start').value, 10) || 1;
-    let e = parseInt(document.getElementById('numa-end').value, 10) || 1;
-    if (s > e) {
-      e = s;
-      document.getElementById('numa-end').value = String(s);
-    }
-    let rangeValues = [];
-    for (let v = s; v <= e; v++) {
-      rangeValues.push(v);
-    }
-
-    // 7) Leer “Chain” (mínimo 2); si es menor, forzamos a 2
-    // 7) Leer “Chain” (mínimo 2); si es menor, forzamos a 2
-let ch = parseInt(document.getElementById('numa-chain').value, 10) || 1;
-
-if (ch > 2) {
-  // Reutiliza ya definidas
-  if (randomBtn) {
-    randomBtn.classList.add('active');
-    forceActivateRandom();
-    randomBtn.disabled = true;
-    randomBtn.classList.add('disabled');
-  }
-  if (surgesBtn) {
-    surgesBtn.disabled = true;
-    surgesBtn.classList.add('disabled');
-    surgesBtn.classList.remove('active');
-  }
-} else {
-  if (randomBtn) {
-    randomBtn.disabled = false;
-    randomBtn.classList.remove('disabled');
-    randomBtn.classList.remove('active');
-  }
-  if (surgesBtn) {
-    surgesBtn.disabled = false;
-    surgesBtn.classList.remove('disabled');
-  }
-}
-
-
-
-
-    // 9) Modo Cipher: reemplazar nums y rangeValues por números grandes de 2–3 dígitos
-    if (opsRight.includes('Cipher')) {
-      let bigNums = [];
-      nums.forEach(() => {
-        const digits = (Math.random() < 0.5) ? 2 : 3;
-        const min = (digits === 2 ? 10 : 100);
-        const max = (digits === 2 ? 99 : 999);
-        bigNums.push(Math.floor(Math.random() * (max - min + 1)) + min);
-      });
-      nums = bigNums;
-
-      const countRange = e - s + 1;
-      let bigRange = [];
-      for (let i = 0; i < countRange; i++) {
-        const digits = (Math.random() < 0.5) ? 2 : 3;
-        const min = (digits === 2 ? 10 : 100);
-        const max = (digits === 2 ? 99 : 999);
-        bigRange.push(Math.floor(Math.random() * (max - min + 1)) + min);
-      }
-      rangeValues = bigRange;
-    }
-
-    // 10) Generar todas las combinaciones respetando “chain” y evitando resultados negativos o inválidos
-    const expressions = [];
-    function buildExpr(depth, currValue, exprStr) {
-      if (depth === ch - 1) {
-        expressions.push(exprStr);
-        return;
-      }
-      for (const op of opsLeft) {
-        const nextOperands = ((depth + 1) % 2 === 0) ? nums : rangeValues;
-        for (const next of nextOperands) {
-          const tentativeExpr = exprStr + op + next;
-          const newValue = calc(currValue, op, next);
-
-          if (newValue === null || newValue < 0) {
-            // Intentar invertir operandos solo si es resta o división
-            if (op === '-' || op === '÷') {
-              const altValue = calc(next, op, currValue);
-              if (altValue !== null && altValue >= 0) {
-                const altExpr = String(next) + op + String(currValue);
-                if (depth + 1 === ch) {
-                  expressions.push(altExpr);
-                } else {
-                  buildExpr(depth + 1, altValue, altExpr);
-                }
-                continue; // Ya procesamos esta rama invertida
-              }
-            }
-            // Si la inversión tampoco funciona, descartamos la rama
-            continue;
-          }
-
-          // Si newValue es válido, seguimos la recursión normal
-          buildExpr(depth + 1, newValue, tentativeExpr);
-        }
-      }
-    }
-    for (const first of nums) {
-      buildExpr(0, first, String(first));
-    }
-
-    // 11) Si “Random” está activo (o forzado), barajar el array de expresiones
-    if (opsRight.includes('Random')) {
-      shuffle(expressions);
-    }
-
-    // 12) Modo Surges: ordenar por complejidad creciente
-    if (opsRight.includes('Surges')) {
-      const computeComplexity = expr => {
-        const parts = expr.split(/([+\-×÷])/);
-        let value = parseFloat(parts[0]);
-        let complexity = Math.abs(value);
-        for (let i = 1; i < parts.length; i += 2) {
-          const op = parts[i];
-          const nxt = parseFloat(parts[i + 1]);
-          value = calc(value, op, nxt);
-          if (value === null) break;
-          complexity += Math.abs(value);
-        }
-        return complexity;
-      };
-      expressions.sort((a, b) => computeComplexity(a) - computeComplexity(b));
-    }
-
-    // 13) Estadísticas (opcional) antes de iniciar ejercicios
-    stats.textContent = `Total: ${expressions.length}  Est. tiempo: ${Math.ceil(expressions.length * 5)}s`;
-
-    if (expressions.length === 0) {
-    alert('No se han podido generar ejercicios con la configuración actual.');
-    return;
-}
-    // 14) Arrancar módulo de ejercicios con la lista generada
-    renderExercises(expressions, opsRight);
-  }; // <-- cierra run.onclick
-
-
-
-  function updateTableButtonsForPokerTrain(active) {
-  const allBtns = Array.from(scroll.querySelectorAll('button.numa-num-btn'));
-
-  allBtns.forEach(oldBtn => {
-    const n = +oldBtn.textContent;
-    const isPokerBtn = n >= 1 && n <= 4;
-
-    const newBtn = oldBtn.cloneNode(true);
-    oldBtn.replaceWith(newBtn);
-    newBtn.classList.add('numa-num-btn');
-
-    if (active) {
-      if (isPokerBtn) {
-        
-        newBtn.disabled = false;
-        newBtn.classList.remove('disabled');
-        newBtn.onclick = () => {
-          if (pokerLevel === n) {
-            // Si ya estaba seleccionado, lo desactivo
-            newBtn.classList.remove('active');
-            pokerLevel = null;
-          } else {
-            // Si era otro o ninguno, activo este
-            allBtns.forEach(btn => btn.classList.remove('active'));
-            newBtn.classList.add('active');
-            pokerLevel = n;
-          }
-          updateRunButtonState();
-        };
-      } else {
-        newBtn.disabled = true;
-        newBtn.classList.add('disabled');
-        newBtn.onclick = null;
-      }
-    } else {
-  newBtn.disabled = false;
-  newBtn.classList.remove('disabled');
-  newBtn.classList.remove('active');
-
-  if (isPokerBtn) {
-    pokerLevel = null;
-    updateRunButtonState();
-  }
-
-  newBtn.onclick = () => {
-    newBtn.classList.toggle('active');
-    updateRunButtonState();
-  };
-}
-  });
-
   if (!active) {
-    attachListenersToTableButtons();
+    pokerSelection = { outs: [], types: [] };
   }
-}
-setTimeout(() => {
-  if (randomBtn && surgesBtn) {
-    validateSpinners();
-  } else {
-    console.warn('❌ validateSpinners() cancelado: botones no están listos');
-  }
-}, 50);
- // ← A
- // SEGÚRATE de que esté aquí, al final
- 
-} // <-- cierra export function init
-
-
-// ─────────────────────────────────────────────────────────
-// Utilidades
-// ─────────────────────────────────────────────────────────
-function calc(a, op, b) {
-  switch (op) {
-    case '+':
-      return a + b;
-    case '-':
-      return a - b;
-    case '×':
-      return a * b;
-      
-    case '÷':
-      if (b === 0) return null;
-      return a / b;
-    default:
-      return null;
-  }
+  enforceChainRules();
+  updateRunButtonState();
 }
 
-function shuffle(arr) {
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [arr[i], arr[j]] = [arr[j], arr[i]];
+function createPokerModal() {
+  const overlay = document.createElement('div');
+  overlay.style.position = 'fixed';
+  overlay.style.top = '0';
+  overlay.style.left = '0';
+  overlay.style.right = '0';
+  overlay.style.bottom = '0';
+  overlay.style.background = 'rgba(0,0,0,0.75)';
+  overlay.style.zIndex = '2000';
+  overlay.style.display = 'flex';
+  overlay.style.justifyContent = 'center';
+  overlay.style.alignItems = 'center';
+
+  const modal = document.createElement('div');
+  modal.style.background = '#000';
+  modal.style.border = '1px solid #28a746';
+  modal.style.padding = '1.5rem';
+  modal.style.maxHeight = '80vh';
+  modal.style.overflowY = 'auto';
+  modal.style.minWidth = '320px';
+  modal.style.fontFamily = 'monospace';
+  modal.style.color = '#28a746';
+
+  const title = document.createElement('h3');
+  title.textContent = 'Configurar Poker Train';
+  title.style.marginTop = '0';
+  modal.appendChild(title);
+
+  const outsContainer = document.createElement('div');
+  outsContainer.style.display = 'grid';
+  outsContainer.style.gridTemplateColumns = 'repeat(4, minmax(0, 1fr))';
+  outsContainer.style.gap = '0.5rem';
+  modal.appendChild(outsContainer);
+
+  for (let i = 1; i <= 20; i++) {
+    const label = document.createElement('label');
+    label.style.display = 'flex';
+    label.style.alignItems = 'center';
+    label.style.gap = '0.25rem';
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.value = String(i);
+    input.checked = pokerSelection.outs.includes(i);
+    label.appendChild(input);
+    label.append(String(i));
+    outsContainer.appendChild(label);
   }
-  return arr;
+
+  const typesContainer = document.createElement('div');
+  typesContainer.style.marginTop = '1rem';
+  modal.appendChild(typesContainer);
+
+  const typesTitle = document.createElement('p');
+  typesTitle.textContent = 'Tipos de pregunta';
+  typesContainer.appendChild(typesTitle);
+
+  const typeList = document.createElement('div');
+  typeList.style.display = 'grid';
+  typeList.style.gridTemplateColumns = 'repeat(2, minmax(0, 1fr))';
+  typeList.style.gap = '0.5rem';
+  typesContainer.appendChild(typeList);
+
+  const typeLabels = {
+    percent_flop_turn: 'Flop→Turn (%)',
+    percent_turn_river: 'Turn→River (%)',
+    percent_flop_river: 'Flop→River (%)',
+    odds_flop_turn: 'Flop→Turn (odds)',
+    odds_turn_river: 'Turn→River (odds)',
+    odds_flop_river: 'Flop→River (odds)',
+    percent_to_odds: '% a odds',
+    odds_to_percent: 'odds a %'
+  };
+
+  Object.entries(typeLabels).forEach(([key, labelText]) => {
+    const label = document.createElement('label');
+    label.style.display = 'flex';
+    label.style.alignItems = 'center';
+    label.style.gap = '0.25rem';
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.value = key;
+    input.checked = pokerSelection.types.includes(key);
+    label.appendChild(input);
+    label.append(labelText);
+    typeList.appendChild(label);
+  });
+
+  const actions = document.createElement('div');
+  actions.style.display = 'flex';
+  actions.style.justifyContent = 'flex-end';
+  actions.style.gap = '0.5rem';
+  actions.style.marginTop = '1rem';
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'numa-btn';
+  cancelBtn.type = 'button';
+  cancelBtn.textContent = 'Cancelar';
+  cancelBtn.addEventListener('click', () => {
+    document.body.removeChild(overlay);
+  });
+
+  const saveBtn = document.createElement('button');
+  saveBtn.className = 'numa-btn';
+  saveBtn.type = 'button';
+  saveBtn.textContent = 'Aceptar';
+  saveBtn.addEventListener('click', () => {
+    const selectedOuts = Array.from(outsContainer.querySelectorAll('input[type="checkbox"]:checked')).map(el => Number(el.value));
+    const selectedTypes = Array.from(typeList.querySelectorAll('input[type="checkbox"]:checked')).map(el => el.value);
+    if (selectedOuts.length === 0 || selectedTypes.length === 0) {
+      alert('Selecciona al menos un out y un tipo de pregunta.');
+      return;
+    }
+    pokerSelection = { outs: selectedOuts, types: selectedTypes };
+    setPokerActive(true);
+    document.body.removeChild(overlay);
+  });
+
+  actions.append(cancelBtn, saveBtn);
+  modal.appendChild(actions);
+  overlay.appendChild(modal);
+  return overlay;
+}
+
+function handlePokerClick() {
+  if (pokerActive) {
+    setPokerActive(false);
+    updateRunButtonState();
+    return;
+  }
+  loadPokerData()
+    .then(() => {
+      const modal = createPokerModal();
+      document.body.appendChild(modal);
+    })
+    .catch(() => {
+      alert('No se pudieron cargar los datos de Poker Train.');
+    });
+}
+
+function attachListeners() {
+  leftColumn.querySelectorAll('button.numa-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      btn.classList.toggle('active');
+      updateRunButtonState();
+    });
+  });
+
+  numberGrid.querySelectorAll('button.numa-num-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      btn.classList.toggle('active');
+      updateRunButtonState();
+    });
+  });
+
+  spinners.chain.addEventListener('input', () => {
+    enforceChainRules();
+    updateRunButtonState();
+  });
+  spinners.start.addEventListener('input', () => {
+    readSpinners();
+    updateRunButtonState();
+  });
+  spinners.end.addEventListener('input', () => {
+    readSpinners();
+    updateRunButtonState();
+  });
+
+  modeButtons.forEach((btn, mode) => {
+    btn.addEventListener('click', () => {
+      if (btn.disabled) return;
+      const wasActive = btn.classList.toggle('active');
+      if (mode === 'Random' && wasActive) {
+        const surges = modeButtons.get('Surges');
+        if (surges) {
+          surges.classList.remove('active');
+        }
+      }
+      if (mode === 'Surges' && wasActive) {
+        const random = modeButtons.get('Random');
+        if (random) {
+          random.classList.remove('active');
+        }
+      }
+      if (mode === 'Fugues') {
+        updateFuguesSpeedButtons(btn.classList.contains('active'));
+      }
+      updateRunButtonState();
+    });
+  });
+
+  speedButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (btn.disabled) return;
+      speedButtons.forEach(other => other.classList.remove('active'));
+      btn.classList.add('active');
+      fuguesSpeed = btn.dataset.speed;
+      localStorage.setItem('fuguesSpeed', fuguesSpeed);
+    });
+  });
+
+  pokerButton.addEventListener('click', handlePokerClick);
+}
+
+function hideConfiguration() {
+  if (configWrapper && configWrapper.parentElement) {
+    configWrapper.parentElement.removeChild(configWrapper);
+  }
+}
+
+function showConfiguration() {
+  if (!termContainer) return;
+  termContainer.innerHTML = '';
+  if (configWrapper) {
+    termContainer.appendChild(configWrapper);
+  }
+  enforceChainRules();
+  updateRunButtonState();
+}
+
+async function startSession() {
+  const modes = getModes();
+  const numericExercises = generateNumericExercises(modes);
+  const pokerExercises = await generatePokerExercises();
+  const combined = [...numericExercises, ...pokerExercises];
+
+  if (combined.length === 0) {
+    alert('Selecciona ejercicios antes de comenzar.');
+    return;
+  }
+
+  const shouldShuffle = modes.includes('Random') || pokerExercises.length > 0;
+
+  hideConfiguration();
+
+  renderExercises(combined, {
+    shuffle: shouldShuffle,
+    fuguesSpeed,
+    onExit: () => {
+      showConfiguration();
+    }
+  });
+}
+
+export function init(container) {
+  container.innerHTML = '';
+
+  const term = document.createElement('div');
+  term.id = 'numa-terminal';
+  term.className = 'numa-terminal';
+  container.appendChild(term);
+
+  termContainer = term;
+
+  configWrapper = document.createElement('div');
+  configWrapper.className = 'numa-config-wrapper';
+  term.appendChild(configWrapper);
+
+  cfgContainer = document.createElement('div');
+  cfgContainer.className = 'numa-cfg-container';
+  configWrapper.appendChild(cfgContainer);
+
+  leftColumn = document.createElement('div');
+  leftColumn.className = 'numa-cfg-col';
+  cfgContainer.appendChild(leftColumn);
+
+  const topOps = document.createElement('div');
+  topOps.className = 'numa-cfg-row';
+  leftColumn.appendChild(topOps);
+
+  ['+', '-'].forEach(op => {
+    const btn = document.createElement('button');
+    btn.textContent = op;
+    btn.dataset.op = op;
+    btn.className = 'numa-btn';
+    topOps.appendChild(btn);
+  });
+
+  const bottomOps = document.createElement('div');
+  bottomOps.className = 'numa-cfg-row';
+  leftColumn.appendChild(bottomOps);
+
+  ['×', '÷'].forEach(op => {
+    const btn = document.createElement('button');
+    btn.textContent = op;
+    btn.dataset.op = op;
+    btn.className = 'numa-btn';
+    bottomOps.appendChild(btn);
+  });
+
+  const rightColumn = document.createElement('div');
+  rightColumn.className = 'numa-cfg-col';
+  cfgContainer.appendChild(rightColumn);
+
+  const modeRow = document.createElement('div');
+  modeRow.className = 'numa-cfg-row';
+  rightColumn.appendChild(modeRow);
+
+  const modeOrder = ['Random', 'Mirror', 'Surges', 'Fugues'];
+  const modeLabels = { Random: 'RND', Mirror: 'MRR', Surges: 'SRG', Fugues: 'FGS' };
+  modeOrder.forEach(mode => {
+    const btn = document.createElement('button');
+    btn.textContent = modeLabels[mode];
+    btn.className = 'numa-btn';
+    btn.dataset.mode = mode;
+    modeRow.appendChild(btn);
+    modeButtons.set(mode, btn);
+  });
+
+  const speedRow = document.createElement('div');
+  speedRow.className = 'numa-cfg-row speed-row';
+  rightColumn.appendChild(speedRow);
+  speedButtons = speedLabels.map(label => {
+    const btn = document.createElement('button');
+    btn.textContent = label;
+    btn.dataset.speed = label;
+    btn.className = 'numa-btn disabled';
+    btn.disabled = true;
+    speedRow.appendChild(btn);
+    return btn;
+  });
+  updateFuguesSpeedButtons(false);
+
+  numberGrid = document.createElement('div');
+  numberGrid.className = 'numa-scroll';
+  configWrapper.appendChild(numberGrid);
+  for (let i = 1; i <= 100; i++) {
+    const btn = document.createElement('button');
+    btn.className = 'numa-num-btn';
+    btn.textContent = String(i);
+    numberGrid.appendChild(btn);
+  }
+
+  bottomRowRef = document.createElement('div');
+  bottomRowRef.className = 'numa-bottom';
+  configWrapper.appendChild(bottomRowRef);
+
+  const startSpinner = createSpinner('Inicio:', 'numa-start', 1);
+  const endSpinner = createSpinner('Fin:', 'numa-end', 10);
+  const chainSpinner = createSpinner('Chain:', 'numa-chain', 2);
+  bottomRowRef.appendChild(startSpinner);
+  bottomRowRef.appendChild(endSpinner);
+  bottomRowRef.appendChild(chainSpinner);
+
+  spinners = {
+    start: startSpinner.querySelector('input'),
+    end: endSpinner.querySelector('input'),
+    chain: chainSpinner.querySelector('input')
+  };
+
+  statsBox = document.createElement('div');
+  statsBox.id = 'numa-stats';
+  statsBox.className = 'numa-stats';
+  statsBox.textContent = 'NUMA: 0  Poker: 0  Total: 0';
+  configWrapper.appendChild(statsBox);
+
+  runButton = document.createElement('button');
+  runButton.textContent = 'Comenzar';
+  runButton.className = 'numa-btn disabled';
+  runButton.disabled = true;
+  runButton.addEventListener('click', startSession);
+
+  pokerButton = document.createElement('button');
+  pokerButton.textContent = 'Poker Train';
+  pokerButton.className = 'numa-btn';
+
+  buttonRowRef = document.createElement('div');
+  buttonRowRef.className = 'numa-btn-row';
+  buttonRowRef.appendChild(runButton);
+  buttonRowRef.appendChild(pokerButton);
+  configWrapper.appendChild(buttonRowRef);
+
+  attachListeners();
+  enforceChainRules();
+  updateRunButtonState();
 }

--- a/numaKeypad.js
+++ b/numaKeypad.js
@@ -1,32 +1,56 @@
 // 📁 mathMode/modules/numaKeypad.js
 
+let keypadEl = null;
+
+function buildButton(key) {
+  const btn = document.createElement('button');
+  btn.dataset.key = key;
+  btn.textContent = key;
+  btn.type = 'button';
+  return btn;
+}
+
 export function createNumericKeypad() {
   const term = document.getElementById('numa-terminal');
-  if (!term) return;
+  if (!term) return null;
 
-  const keypad = document.createElement('div');
-  keypad.id = 'numeric-keypad';
+  if (keypadEl && keypadEl.isConnected) {
+    return keypadEl;
+  }
 
-  ['7','8','9','4','5','6','1','2','3','0','C','←'].forEach(key => {
-    const btn = document.createElement('button');
-    btn.dataset.key = key;
-    btn.textContent = key;
-    keypad.appendChild(btn);
-  });
+  keypadEl = document.createElement('div');
+  keypadEl.id = 'numeric-keypad';
 
-  term.appendChild(keypad);
+  const keys = ['7','8','9','%','4','5','6',':','1','2','3','.', '0','C','←'];
+  keys.forEach(key => keypadEl.appendChild(buildButton(key)));
 
-  keypad.addEventListener('click', e => {
-    if (e.target.tagName !== 'BUTTON') return;
-    const k = e.target.dataset.key;
+  keypadEl.addEventListener('click', e => {
+    const target = e.target;
+    if (!(target instanceof HTMLButtonElement)) return;
+
+    const key = target.dataset.key;
     const input = document.querySelector('.answer-input');
     if (!input) return;
 
-    if (k === 'C')      input.value = '';
-    else if (k === '←') input.value = input.value.slice(0, -1);
-    else                input.value += k;
+    if (key === 'C') {
+      input.value = '';
+    } else if (key === '←') {
+      input.value = input.value.slice(0, -1);
+    } else {
+      input.value += key;
+    }
 
     input.focus();
     input.dispatchEvent(new Event('input'));
   });
+
+  term.appendChild(keypadEl);
+  return keypadEl;
+}
+
+export function removeNumericKeypad() {
+  if (keypadEl && keypadEl.isConnected) {
+    keypadEl.remove();
+  }
+  keypadEl = null;
 }


### PR DESCRIPTION
## Summary
- replace the NUMA setup with a stable configuration wrapper that keeps selections, validates spinners and builds numeric sequences deterministically
- add a Poker Train modal fed from potOdds.json, merging its questions with NUMA exercises and restoring the setup after each run
- rebuild the exercise renderer and keypad to support the mobile keypad extensions, re-ask failed questions and allow resetting/shuffling sessions

## Testing
- Not run (manual validation only)

------
https://chatgpt.com/codex/tasks/task_e_68cd055eb850832ab2b7cfb170c7ffeb